### PR TITLE
Refactor: Convert mock class to Singleton, add attribute and add test case 

### DIFF
--- a/src/main/java/th/ac/kmitl/science/comsci/example/models/Person.java
+++ b/src/main/java/th/ac/kmitl/science/comsci/example/models/Person.java
@@ -1,19 +1,28 @@
 package th.ac.kmitl.science.comsci.example.models;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public abstract class Person {
     
-    private String id;  
+    private String id;
     private String globalId; 
     private String name; 
     private String taxId;  
-    private String uriId;
-    
-    public String getUriId() {
-        return uriId;
-    }
+    private Address address;
+    private List<UniversalCommunication> universalCommunication;
 
-    public void setUriId(String uriId) {
-        this.uriId = uriId;
+    public Person() {
+        address = new Address();
+        universalCommunication = new ArrayList<>();
+    }
+    
+    public List<UniversalCommunication> getUniversalCommunication() {
+        return universalCommunication;
+    }
+ 
+    public Address getAddress() {
+        return address;
     }
 
     public String getTaxId() {

--- a/src/main/java/th/ac/kmitl/science/comsci/example/models/Trader.java
+++ b/src/main/java/th/ac/kmitl/science/comsci/example/models/Trader.java
@@ -15,13 +15,13 @@ public class Trader extends Person{
     
     @Override
     public boolean equals(Object obj) {
-        Trader other = (Trader) obj;
+        Trader trader = (Trader) obj;
         
         return (obj instanceof Trader) &&
-                getId().equals(other.getId()) &&
-                getName().equals(other.getName()) &&
-                getGlobalId().equals(other.getGlobalId()) &&
-                getTaxId().equals(other.getTaxId());
+                getId().equals(trader.getId()) &&
+                getName().equals(trader.getName()) &&
+                getGlobalId().equals(trader.getGlobalId()) &&
+                getTaxId().equals(trader.getTaxId());
     }
 
     @Override

--- a/src/main/java/th/ac/kmitl/science/comsci/example/models/Trader.java
+++ b/src/main/java/th/ac/kmitl/science/comsci/example/models/Trader.java
@@ -2,25 +2,26 @@ package th.ac.kmitl.science.comsci.example.models;
 
 public class Trader extends Person{
     
-    public Trader(String name, 
+    public Trader(String id,
+                  String name, 
                   String globalId, 
-                  String taxId,
-                  String uriId) {
+                  String taxId) {
+        super();
+        setId(id);
         setName(name);
         setGlobalId(globalId);
         setTaxId(taxId);
-        setUriId(uriId);
     }
-
+    
     @Override
     public boolean equals(Object obj) {
         Trader other = (Trader) obj;
         
-        return (obj instanceof Trader) && 
+        return (obj instanceof Trader) &&
+                getId().equals(other.getId()) &&
                 getName().equals(other.getName()) &&
                 getGlobalId().equals(other.getGlobalId()) &&
-                getTaxId().equals(other.getTaxId()) &&
-                getUriId().equals(other.getUriId());
+                getTaxId().equals(other.getTaxId());
     }
 
     @Override

--- a/src/main/java/th/ac/kmitl/science/comsci/example/models/UniversalCommunication.java
+++ b/src/main/java/th/ac/kmitl/science/comsci/example/models/UniversalCommunication.java
@@ -13,7 +13,7 @@ public class UniversalCommunication{
     }
     
     public UniversalCommunication(String uriId){
-        setUriId(uriId);
+        this.uriId = uriId;
     }
     
     @Override

--- a/src/main/java/th/ac/kmitl/science/comsci/example/models/mock/AddressMock.java
+++ b/src/main/java/th/ac/kmitl/science/comsci/example/models/mock/AddressMock.java
@@ -22,7 +22,7 @@ public class AddressMock {
         
     private AddressMock(){
             
-    }
+    } 
          
     public static Address generateAddressMock(){
         if(addressInstanceMock == null){

--- a/src/main/java/th/ac/kmitl/science/comsci/example/models/mock/AddressMock.java
+++ b/src/main/java/th/ac/kmitl/science/comsci/example/models/mock/AddressMock.java
@@ -4,34 +4,47 @@ import th.ac.kmitl.science.comsci.example.models.Address;
 
 public class AddressMock {
     
-        public static String postCode = "20000";
-        public static String buildingName = "Bangfore Building";
-        public static String lineOne = "Burapha";
-        public static String lineTwo = "Bhanmpa";
-        public static String lineThree = "Soi4";   
-        public static String lineFour = "";  
-        public static String lineFive = "3";
-        public static String streetName = "Ratwipa";
-        public static String cityName = "BanBung";
-        public static String citySubDivisionName = "Saksan";
-        public static String countryName = "Thailand"; 
-        public static String countrySubDivisionName = "Chonburi";
-        public static String buildingNumber = "33/99"; 
+    private static Address addressInstanceMock;
+    
+    public static String postCode = "20000";
+    public static String buildingName = "Bangfore Building";
+    public static String lineOne = "Burapha";
+    public static String lineTwo = "Bhanmpa";
+    public static String lineThree = "Soi4";   
+    public static String lineFour = "";  
+    public static String lineFive = "3";
+    public static String streetName = "Ratwipa";
+    public static String cityName = "BanBung";
+    public static String citySubDivisionName = "Saksan";
+    public static String countryName = "Thailand"; 
+    public static String countrySubDivisionName = "Chonburi";
+    public static String buildingNumber = "33/99";
         
-        public static Address getAddressMock(){
-            return new Address(
-                postCode,
-                buildingName,
-                lineOne,
-                lineTwo,
-                lineThree,
-                lineFour,
-                lineFive,
-                streetName,
-                cityName,
-                citySubDivisionName,
-                countryName,
-                countrySubDivisionName,
-                buildingNumber);
+    private AddressMock(){
+            
+    }
+         
+    public static Address generateAddressMock(){
+        if(addressInstanceMock == null){
+            addressInstanceMock = new Address(
+            postCode,
+            buildingName,
+            lineOne,
+            lineTwo,
+            lineThree,
+            lineFour,
+            lineFive,
+            streetName,
+            cityName,
+            citySubDivisionName,
+            countryName,
+            countrySubDivisionName,
+            buildingNumber);
+            
+            return addressInstanceMock;
+        }else{
+            return addressInstanceMock;
         }
+    }
+    
 }

--- a/src/main/java/th/ac/kmitl/science/comsci/example/models/mock/AddressMock.java
+++ b/src/main/java/th/ac/kmitl/science/comsci/example/models/mock/AddressMock.java
@@ -4,47 +4,34 @@ import th.ac.kmitl.science.comsci.example.models.Address;
 
 public class AddressMock {
     
-    private static Address addressInstanceMock;
-    
-    public static String postCode = "20000";
-    public static String buildingName = "Bangfore Building";
-    public static String lineOne = "Burapha";
-    public static String lineTwo = "Bhanmpa";
-    public static String lineThree = "Soi4";   
-    public static String lineFour = "";  
-    public static String lineFive = "3";
-    public static String streetName = "Ratwipa";
-    public static String cityName = "BanBung";
-    public static String citySubDivisionName = "Saksan";
-    public static String countryName = "Thailand"; 
-    public static String countrySubDivisionName = "Chonburi";
-    public static String buildingNumber = "33/99";
+        public static String postCode = "20000";
+        public static String buildingName = "Bangfore Building";
+        public static String lineOne = "Burapha";
+        public static String lineTwo = "Bhanmpa";
+        public static String lineThree = "Soi4";   
+        public static String lineFour = "";  
+        public static String lineFive = "3";
+        public static String streetName = "Ratwipa";
+        public static String cityName = "BanBung";
+        public static String citySubDivisionName = "Saksan";
+        public static String countryName = "Thailand"; 
+        public static String countrySubDivisionName = "Chonburi";
+        public static String buildingNumber = "33/99"; 
         
-    private AddressMock(){
-            
-    }
-         
-    public static Address generateAddressMock(){
-        if(addressInstanceMock == null){
-            addressInstanceMock = new Address(
-            postCode,
-            buildingName,
-            lineOne,
-            lineTwo,
-            lineThree,
-            lineFour,
-            lineFive,
-            streetName,
-            cityName,
-            citySubDivisionName,
-            countryName,
-            countrySubDivisionName,
-            buildingNumber);
-            
-            return addressInstanceMock;
-        }else{
-            return addressInstanceMock;
+        public static Address getAddressMock(){
+            return new Address(
+                postCode,
+                buildingName,
+                lineOne,
+                lineTwo,
+                lineThree,
+                lineFour,
+                lineFive,
+                streetName,
+                cityName,
+                citySubDivisionName,
+                countryName,
+                countrySubDivisionName,
+                buildingNumber);
         }
-    }
-    
 }

--- a/src/main/java/th/ac/kmitl/science/comsci/example/models/mock/AddressMock.java
+++ b/src/main/java/th/ac/kmitl/science/comsci/example/models/mock/AddressMock.java
@@ -22,7 +22,7 @@ public class AddressMock {
         
     private AddressMock(){
             
-    } 
+    }
          
     public static Address generateAddressMock(){
         if(addressInstanceMock == null){

--- a/src/main/java/th/ac/kmitl/science/comsci/example/models/mock/TraderMock.java
+++ b/src/main/java/th/ac/kmitl/science/comsci/example/models/mock/TraderMock.java
@@ -4,40 +4,64 @@ import th.ac.kmitl.science.comsci.example.models.Trader;
 
 public class TraderMock {
     
+    private static Trader traderInstanceMock;
+    private static Trader newTraderInstanceMock;
+    private static Trader nullTraderInstanceMock;
+    
+    public static String id = "PLLka112DF";
     public static String name = "Sutit Puyta";
     public static String globalId = "GGIM12345";
     public static String taxId = "TAX55612";
-    public static String uriId = "URI665H16";
     
+    public static String newId = "Aiika112DF";
     public static String newName = "Umnami Yuna";
     public static String newGlobalId = "NEWG556I";
     public static String newTaxId = "TAXnew111";
-    public static String newUriId = "UNew664ee";
     
-    public static Trader getTraderMock(){
-        return new Trader(
+    private TraderMock(){
+        
+    }
+    
+    public static Trader generateTraderMock(){
+        if(traderInstanceMock == null){
+            traderInstanceMock = new Trader(
+                id,
                 name,
                 globalId,
-                taxId,
-                uriId
-        );
+                taxId);
+            
+            return traderInstanceMock;
+        }else{
+            return traderInstanceMock;
+        }
     }
     
-    public static Trader getNewTraderMock(){
-        return new Trader(
+    public static Trader generateNewTraderMock(){
+        if(newTraderInstanceMock == null){
+            newTraderInstanceMock = new Trader(
+                newId,
                 newName,
                 newGlobalId,
-                newTaxId,
-                newUriId
-        );
+                newTaxId);
+            
+            return newTraderInstanceMock;
+        }else{
+            return newTraderInstanceMock;
+        }
     }
     
-    public static Trader getNullTraderMock(){
-        return new Trader(
+    public static Trader generateNullTraderMock(){
+        if(nullTraderInstanceMock == null){
+            nullTraderInstanceMock = new Trader(
                 "",
                 "",
                 "",
-                ""
-        );
+                "");
+            
+            return nullTraderInstanceMock;
+        }else{
+            return nullTraderInstanceMock;
+        }
     }
+    
 }

--- a/src/main/java/th/ac/kmitl/science/comsci/example/models/mock/UniversalCommunicationMock.java
+++ b/src/main/java/th/ac/kmitl/science/comsci/example/models/mock/UniversalCommunicationMock.java
@@ -4,14 +4,39 @@ import th.ac.kmitl.science.comsci.example.models.UniversalCommunication;
 
 public class UniversalCommunicationMock {
     
+    private static UniversalCommunication 
+            universalCommunicationInstanceMock;
+    private static UniversalCommunication
+            newUniversalCommunicationInstanceMock;
+    
+    private UniversalCommunicationMock(){
+        
+    }
+    
     public static String uriId = "uniMail@GGmail.com";
     public static String newUriId = "newMail@GGmail.com";
     
-    public static UniversalCommunication getUniversalCommunication(){
-        return new UniversalCommunication(uriId);
+    public static UniversalCommunication generateUniversalCommunication(){
+        if(universalCommunicationInstanceMock == null){
+            universalCommunicationInstanceMock = 
+                    new UniversalCommunication(uriId);
+            
+            return universalCommunicationInstanceMock;
+        }else{
+            return universalCommunicationInstanceMock;
+        }
+        
     }
     
-    public static UniversalCommunication getNewUniversalCommunication(){
-        return new UniversalCommunication(newUriId);
+    public static UniversalCommunication generateNewUniversalCommunication(){
+        if(newUniversalCommunicationInstanceMock == null){
+            newUniversalCommunicationInstanceMock = 
+                    new UniversalCommunication(newUriId);
+            
+            return newUniversalCommunicationInstanceMock;
+        }else{
+            return newUniversalCommunicationInstanceMock;
+        }
     }
+    
 }

--- a/src/test/java/th/ac/kmitl/science/comsci/example/models/AddressTest.java
+++ b/src/test/java/th/ac/kmitl/science/comsci/example/models/AddressTest.java
@@ -52,7 +52,7 @@ public class AddressTest {
     
     @Test
     public void canSetAttributeAddress(){      
-        Address addressObject = new Address();
+        Address addressObject = AddressMock.generateAddressMock();
         
         addressObject.setPostCode(AddressMock.postCode);
         addressObject.setBuildingName(AddressMock.buildingName);

--- a/src/test/java/th/ac/kmitl/science/comsci/example/models/TraderTest.java
+++ b/src/test/java/th/ac/kmitl/science/comsci/example/models/TraderTest.java
@@ -1,73 +1,135 @@
 package th.ac.kmitl.science.comsci.example.models;
 
+import static org.junit.Assert.assertFalse;
 import org.junit.Test;
+import th.ac.kmitl.science.comsci.example.models.mock.TraderMock;
+import th.ac.kmitl.science.comsci.example.models.mock.AddressMock;
+import th.ac.kmitl.science.comsci.example.models.mock.UniversalCommunicationMock;
 
 public class TraderTest {
     
     @Test
-    public void creatTraderObjectCorrectly(){
-        String name = "Sutit Puyta";
-        String globalId = "GGIM12345";
-        String taxId = "TAX55612";
-        String uriId = "URI665H16";
+    public void createTraderObjectCorrectly(){      
+        Trader traderObject = new Trader(
+                TraderMock.id,
+                TraderMock.name,
+                TraderMock.globalId, 
+                TraderMock.taxId);
         
-        Trader traderObject = new Trader(name, globalId, taxId, uriId);
-        
-        assert(traderObject.getName().equals(name));
-        assert(traderObject.getGlobalId().equals(globalId));
-        assert(traderObject.getTaxId().equals(taxId));
-        assert(traderObject.getUriId().equals(uriId));
+        assert(traderObject.getName().equals(TraderMock.name));
+        assert(traderObject.getGlobalId().equals(TraderMock.globalId));
+        assert(traderObject.getTaxId().equals(TraderMock.taxId));
     }
     
     @Test
-    public void setAttributeTraderCorrectly(){
-        String name = "Sutit Puyta";
-        String globalId = "GGIM12345";
-        String taxId = "TAX55612";
-        String uriId = "URI665H16";
+    public void setAttributeTraderCorrectly(){      
+        Trader traderObject = TraderMock.generateTraderMock();
         
-        String newName = "Umnami Yuna";
-        String newGlobalId = "NEWG556I";
-        String newTaxId = "TAXnew111";
-        String newUriId = "UNew664ee";
+        traderObject.setName(TraderMock.newName);
+        traderObject.setGlobalId(TraderMock.newGlobalId);
+        traderObject.setTaxId(TraderMock.newTaxId);
         
-        Trader traderObject = new Trader(name, globalId, taxId, uriId);
-        
-        traderObject.setName(newName);
-        traderObject.setGlobalId(newGlobalId);
-        traderObject.setTaxId(newTaxId);
-        traderObject.setUriId(newUriId);
-        
-        assert(traderObject.getName().equals(newName));
-        assert(traderObject.getGlobalId().equals(newGlobalId));
-        assert(traderObject.getTaxId().equals(newTaxId));
-        assert(traderObject.getUriId().equals(newUriId));
+        assert(traderObject.getName().equals(TraderMock.newName));
+        assert(traderObject.getGlobalId().equals(TraderMock.newGlobalId));
+        assert(traderObject.getTaxId().equals(TraderMock.newTaxId));
     }
     
     @Test
-    public void canCompareNullTraderObject(){
-        String name = "";
-        String globalId = "";
-        String taxId = "";
-        String uriId = "";
-        
-        Trader traderInitailObject = new Trader(name, globalId, taxId, uriId);
-        Trader traderCompareObject = new Trader(name, globalId, taxId, uriId);
+    public void canCompareNullTraderObject(){      
+        Trader traderInitailObject = TraderMock.generateNullTraderMock();
+        Trader traderCompareObject = TraderMock.generateNullTraderMock();
         
         assert(traderInitailObject.equals(traderCompareObject));
     }
     
     @Test
-    public void canCompareEqualsTraderObject(){
-        String name = "Sutit Puyta";
-        String globalId = "GGIM12345";
-        String taxId = "TAX55612";
-        String uriId = "URI665H16";
-        
-        Trader traderInitailObject = new Trader(name, globalId, taxId, uriId);
-        Trader traderCompareObject = new Trader(name, globalId, taxId, uriId);
+    public void canCompareEqualsTraderObject(){      
+        Trader traderInitailObject = TraderMock.generateTraderMock();
+        Trader traderCompareObject = TraderMock.generateTraderMock();
         
         assert(traderInitailObject.equals(traderCompareObject));
+    }
+    
+    @Test
+    public void canCompareDifferenceTraderObject(){    
+        Trader traderInitailObject = TraderMock.generateTraderMock();
+        Trader traderCompareObject = TraderMock.generateNewTraderMock();
+        
+        assertFalse(traderInitailObject.equals(traderCompareObject));
+    }
+    
+    @Test
+    public void canSetGetTraderAddressCorrectly(){
+        Trader traderObject = TraderMock.generateTraderMock();      
+        Address traderAddress = traderObject.getAddress();
+        
+        traderAddress.setPostCode(AddressMock.postCode);
+        traderAddress.setBuildingName(AddressMock.buildingName);
+        traderAddress.setLineOne(AddressMock.lineOne);
+        traderAddress.setLineTwo(AddressMock.lineTwo);
+        traderAddress.setLineThree(AddressMock.lineThree);
+        traderAddress.setLineFour(AddressMock.lineFour);
+        traderAddress.setLineFive(AddressMock.lineFive);
+        traderAddress.setStreetName(AddressMock.streetName);
+        traderAddress.setCityName(AddressMock.cityName);
+        traderAddress.setCitySubDivisionName(AddressMock.citySubDivisionName);
+        traderAddress.setCountryName(AddressMock.countryName);
+        traderAddress.setCountrySubDivisionName(AddressMock.countrySubDivisionName);
+        traderAddress.setBuildingNumber(AddressMock.buildingNumber);
+        
+        assert(traderAddress.getPostCode()
+                .equals(AddressMock.postCode));
+        assert(traderAddress.getBuildingName()
+                .equals(AddressMock.buildingName));
+        assert(traderAddress.getLineOne()
+                .equals(AddressMock.lineOne));
+        assert(traderAddress.getLineTwo()
+                .equals(AddressMock.lineTwo));
+        assert(traderAddress.getLineThree()
+                .equals(AddressMock.lineThree));
+        assert(traderAddress.getLineFour()
+                .equals(AddressMock.lineFour));
+        assert(traderAddress.getLineFive()
+                .equals(AddressMock.lineFive));
+        assert(traderAddress.getStreetName()
+                .equals(AddressMock.streetName));
+        assert(traderAddress.getCityName()
+                .equals(AddressMock.cityName));
+        assert(traderAddress.getCitySubDivisionName()
+                .equals(AddressMock.citySubDivisionName));
+        assert(traderAddress.getCountryName()
+                .equals(AddressMock.countryName));
+        assert(traderAddress.getCountrySubDivisionName()
+                .equals(AddressMock.countrySubDivisionName));
+        assert(traderAddress.getBuildingNumber()
+                .equals(AddressMock.buildingNumber));
+    }
+    
+    @Test
+    public void canAddTraderUniversalComunication(){
+        Trader traderObject = TraderMock.generateTraderMock();
+        
+        traderObject.getUniversalCommunication()
+                .add(UniversalCommunicationMock
+                        .generateUniversalCommunication());
+        
+        assert(traderObject.getUniversalCommunication().get(0)
+                .equals(UniversalCommunicationMock
+                        .generateUniversalCommunication()));
+    }
+     
+    @Test
+    public void canAddTraderUniversalComunicationByFactory(){
+        Trader traderObject = TraderMock.generateTraderMock();
+        
+        traderObject.getUniversalCommunication()
+                .add(TradeContactFactory
+                .createTraderContact(UniversalCommunicationMock.uriId));  
+        
+        assert(traderObject.getUniversalCommunication()
+                .get(0)
+                .getUriId()
+                .equals(UniversalCommunicationMock.uriId));
     }
     
 }

--- a/src/test/java/th/ac/kmitl/science/comsci/example/models/UniversalCommunicationTest.java
+++ b/src/test/java/th/ac/kmitl/science/comsci/example/models/UniversalCommunicationTest.java
@@ -18,10 +18,10 @@ public class UniversalCommunicationTest {
     @Test
     public void setUriIdUniversalCommunicationOjectCorrectly(){
         UniversalCommunication initailCommunication = 
-                UniversalCommunicationMock.getUniversalCommunication();
+                UniversalCommunicationMock.generateUniversalCommunication();
         
         UniversalCommunication newCommunication = 
-                UniversalCommunicationMock.getNewUniversalCommunication();
+                UniversalCommunicationMock.generateNewUniversalCommunication();
         
         assertFalse(initailCommunication.equals(newCommunication));
     }
@@ -29,10 +29,10 @@ public class UniversalCommunicationTest {
     @Test
     public void canCompareUniversalCommunicationOject(){
         UniversalCommunication initailCommunication = 
-                UniversalCommunicationMock.getUniversalCommunication();
+                UniversalCommunicationMock.generateUniversalCommunication();
         
         UniversalCommunication compareCommunication = 
-                UniversalCommunicationMock.getUniversalCommunication();
+                UniversalCommunicationMock.generateUniversalCommunication();
         
         assert(initailCommunication.equals(compareCommunication));
     }


### PR DESCRIPTION
- UniversalCommunicationMock, AddressMock and TraderMock class: Rename method in mock class from get to generate and convert to sigleton.

- Person class: Add attribute address, universalCommunication and create constructor method.

- Trader class: Edit constructor by add id parameter and remove uriId parameter. Add super method in constructor.

- UniversalCommunication class: Edit constructor method from call method setUriId to assign attribute.

- TraderTest, UniversalCommunocationTest and AddressTest class:  change data receive from mock.


